### PR TITLE
Fix version conflicts caused by PR#537

### DIFF
--- a/src/SIO.Infrastructure.AWS/SIO.Infrastructure.AWS.csproj
+++ b/src/SIO.Infrastructure.AWS/SIO.Infrastructure.AWS.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Polly" Version="3.5.1.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.4.1" />
+    <PackageReference Include="AWSSDK.Polly" Version="3.7.1.13" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.1.13" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump AWSSDK.Polly from 3.5.1.1 to 3.7.1.13. [(PR#537)](https://github.com/sound-it-out/sio-api/pull/537).
Hope this fix can help you.

Best regards,
sucrose